### PR TITLE
1021465: Update README for Blazor Rich Text Editor export to RTF sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,53 @@
-# Blazor Rich Text Editor export to RTF file
+# Blazor Rich Text Editor Export to RTF file
 
-The Rich Text Editor content export to RTF file While cliking on the export button, in the button click action call export service and convert to the RTF file using [Syncfusion.DocIO](https://www.syncfusion.com/document-processing/word-framework/net) libraries.
+A Blazor sample demonstrating how to export Rich Text Editor content to an RTF file using Syncfusion.DocIO.
+
+## Project Overview
+
+Example showing how to export Rich Text Editor content to an RTF file by calling an export service that converts editor content to RTF using Syncfusion.DocIO.
+
+## Key Points
+
+- Export editor content to RTF
+- Uses Syncfusion.DocIO for conversion
 
 ## Prerequisites
 
-* Visual Studio 2022
+- .NET 8.0 SDK
+- Visual Studio 2022+ or VS Code
+- Syncfusion DocIO license (if required)
 
-## How to run the project
+## Setup & Running Steps
 
-* Checkout this project to a location in your disk.
-* Open the solution file using the Visual Studio 2022.
-* Restore the NuGet packages by rebuilding the solution.
-* Run the project.
+Installation
+
+```bash
+git clone https://github.com/SyncfusionExamples/blazor-rich-text-editor-export-to-rtf.git
+cd blazor-rich-text-editor-export-to-rtf
+```
+
+Restore NuGet packages
+
+```bash
+dotnet restore
+```
+
+Run the application
+
+```bash
+dotnet run
+```
+
+## Usage
+
+Enter content in the Rich Text Editor and click the export button to convert and download an RTF file.
+
+## Troubleshooting
+
+- Restore NuGet packages and ensure the project builds.
+- Verify Syncfusion license configuration and check logs for errors.
 
 ## See also
-* [Online examples](https://blazor.syncfusion.com/demos/rich-text-editor/overview?theme=fluent)
-* [Documentation](https://blazor.syncfusion.com/documentation/rich-text-editor/getting-started)
+
+- [Online examples](https://blazor.syncfusion.com/demos/rich-text-editor/overview?theme=fluent)
+- [Documentation](https://blazor.syncfusion.com/documentation/rich-text-editor/getting-started)

--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ Enter content in the Rich Text Editor and click the export button to convert and
 
 ## Troubleshooting
 
-- Restore NuGet packages and ensure the project builds.
-- Verify Syncfusion license configuration and check logs for errors.
+- Ensure NuGet packages are restored and the project builds before running.
+- If export fails, check browser console and server logs for errors and confirm any required licenses are configured.
+
+## Support
+
+This sample is provided for demonstration purposes. For issues, open an issue in the repository.
 
 ## See also
 
-- [Online examples](https://blazor.syncfusion.com/demos/rich-text-editor/overview?theme=fluent)
-- [Documentation](https://blazor.syncfusion.com/documentation/rich-text-editor/getting-started)
+- [Online examples](https://blazor.syncfusion.com/demos/rich-text-editor/overview?theme=fluent2)
+- [Documentation](https://blazor.syncfusion.com/documentation/rich-text-editor/getting-started-webapp)


### PR DESCRIPTION
Updated the README to describe how to export Blazor Rich Text Editor content to an RTF file using Syncfusion.DocIO.